### PR TITLE
Version 0.4.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,16 +14,15 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: cd dist && {{ PYTHON }} -m pip install . -vv
+  script: cd dist && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
     - poetry-core >=1.0.0
   run:
-    - python >=3.7
+    - python
 
 test:
   source_files:


### PR DESCRIPTION
Pathable 0.4.3

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/p1c2u/pathable)
- Relevant dependency PRs:
  - For `jsonschema-path-feedstock` which is for `moto`

### Explanation of changes:

- modernise recipe for main upload (currently only on forklift)