### PR TITLE
0.4.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,11 @@ test:
 about:
   home: https://github.com/p1c2u/pathable
   summary: Object-oriented paths
+  description: Object-oriented paths
+  dev_url: https://github.com/p1c2u/pathable
+  doc_url: https://github.com/p1c2u/pathable
   license: Apache-2.0
+  license_family: Apache
   license_file: dist/LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,16 +14,15 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: cd dist && {{ PYTHON }} -m pip install . -vv
+  script: cd dist && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
     - poetry-core >=1.0.0
   run:
-    - python >=3.7
+    - python
 
 test:
   source_files:


### PR DESCRIPTION
Pathable 0.4.3

**Destination channel:** defaults

### Links
- [PKG-4400](https://anaconda.atlassian.net/browse/PKG-4400)
- [Upstream repository](https://github.com/p1c2u/pathable)
- Relevant dependency PRs:
  - For `jsonschema-path-feedstock` which is for `moto`

### Explanation of changes:

- modernise recipe for main upload (currently only on forklift)


[PKG-4400]: https://anaconda.atlassian.net/browse/PKG-4400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ